### PR TITLE
correct no3- and no2- superscript

### DIFF
--- a/sections/nitrate_sensors_integration.md
+++ b/sections/nitrate_sensors_integration.md
@@ -79,7 +79,7 @@ The LoC analyser contains a three layer poly(methyl methacrylate) (PMMA) optoflu
 The chip forms the end cap of a dark watertight pressure compensated PVC housing, which is rated to 6000 dbar. The chip is fitted with a cadmium column for the reduction of nitrate to nitrite. 
 The system is automated using a 32 bit microcontroller-based electronics package with 18-bit analogue to digital inputs and can stream raw data (1 Hz) over USB, as well as store data on a 8 GB flash memory card. 
 Provided with the values of the on-board standards, the LoC analyser is capable of outputting processed data (µM NO<sub>2-</sub><sup>-</sup> + NO<sub>3-</sub><sup>-</sup>) over RS232 or RS485 interfaces {cite}`Beaton2012`. 
-The analyser is capable of measuring concentrations ranging from 0.025 to 1000 µM NO<sub>3</sub> due to the chip containing 3 measurement cells with differing path lengths. 
+The analyser is capable of measuring concentrations ranging from 0.025 to 1000 µM NO<sub>3</sub><sup>-</sup> due to the chip containing 3 measurement cells with differing path lengths. 
 Measurement frequency during glider operations is approximately every 7 minutes, this is preceded by a calibration period of approximately 21 minutes during which blank and standard measurements are made at the start of each dive.  
 
 ## Instrument comparison and uncertainty numbers
@@ -109,7 +109,7 @@ Bio-fouling and other influences are not included.
 
 |   |  Sample rate  |  Power |  Manufacturer Accuracy | Manufacturer Precision |  Manufacturer Detection limit |  Precision estimate |  Accuracy estimate (w. x-cali.) |
 |---|---|---|---|---|---|---|---|
-|   | Hz | W | µM NO<sub>3</sub> | µM NO<sub>3</sub> | µM NO<sub>3</sub> | µM NO<sub>3</sub> | µM NO<sub>3</sub> |
+|   | Hz | W | µM NO<sub>3</sub> | µM NO<sub>3</sub><sup>-</sup> | µM NO<sub>3</sub><sup>-</sup> | µM NO<sub>3</sub><sup>-</sup> | µM NO<sub>3</sub><sup>-</sup> |
 | Deep SUNA  | 1 | <=8 | 10% or >=2.0 (+0.3 / hr lamp) | 0.3 (2.4 SW sal) | 0.5 (2.0 SW sal) | 0.17 (4) | 0.5-1.0 (5) |
 | OPUS  | 1/3 | <=8 | 5% +0.7 | 0.36 (3) | 2.1 | 1.3 (4) | 1.0 (5)  |
 | LoC  | 0.0002 (7 min) | 1.5 | 3 % for concentration range 5.63 to 44.43 (1) | 4 % for concentration range 5.63 to 44.43 (1) | 0.025 | 0.14 (2) |   |

--- a/sections/nitrate_sensors_integration.md
+++ b/sections/nitrate_sensors_integration.md
@@ -78,7 +78,7 @@ A variant of this sensor that measures phosphate has also been developed and dep
 The LoC analyser contains a three layer poly(methyl methacrylate) (PMMA) optofluidic chip with precision milled microchannels, mixers and optical components consisting of light emitting diodes and photodiodes, electronics, solenoid valves and syringe pumps mounted on the chip. 
 The chip forms the end cap of a dark watertight pressure compensated PVC housing, which is rated to 6000 dbar. The chip is fitted with a cadmium column for the reduction of nitrate to nitrite. 
 The system is automated using a 32 bit microcontroller-based electronics package with 18-bit analogue to digital inputs and can stream raw data (1 Hz) over USB, as well as store data on a 8 GB flash memory card. 
-Provided with the values of the on-board standards, the LoC analyser is capable of outputting processed data (µM NO<sub>2-</sub> + NO<sub>3-</sub>) over RS232 or RS485 interfaces {cite}`Beaton2012`. 
+Provided with the values of the on-board standards, the LoC analyser is capable of outputting processed data (µM NO<sub>2</sub><sup>-</sup> + NO<sub>3</sub><sup>-</sup>) over RS232 or RS485 interfaces {cite}`Beaton2012`. 
 The analyser is capable of measuring concentrations ranging from 0.025 to 1000 µM NO<sub>3</sub> due to the chip containing 3 measurement cells with differing path lengths. 
 Measurement frequency during glider operations is approximately every 7 minutes, this is preceded by a calibration period of approximately 21 minutes during which blank and standard measurements are made at the start of each dive.  
 

--- a/sections/nitrate_sensors_integration.md
+++ b/sections/nitrate_sensors_integration.md
@@ -78,7 +78,7 @@ A variant of this sensor that measures phosphate has also been developed and dep
 The LoC analyser contains a three layer poly(methyl methacrylate) (PMMA) optofluidic chip with precision milled microchannels, mixers and optical components consisting of light emitting diodes and photodiodes, electronics, solenoid valves and syringe pumps mounted on the chip. 
 The chip forms the end cap of a dark watertight pressure compensated PVC housing, which is rated to 6000 dbar. The chip is fitted with a cadmium column for the reduction of nitrate to nitrite. 
 The system is automated using a 32 bit microcontroller-based electronics package with 18-bit analogue to digital inputs and can stream raw data (1 Hz) over USB, as well as store data on a 8 GB flash memory card. 
-Provided with the values of the on-board standards, the LoC analyser is capable of outputting processed data (µM NO<sub>2</sub><sup>-</sup> + NO<sub>3</sub><sup>-</sup>) over RS232 or RS485 interfaces {cite}`Beaton2012`. 
+Provided with the values of the on-board standards, the LoC analyser is capable of outputting processed data (µM NO<sub>2-</sub><sup>-</sup> + NO<sub>3-</sub><sup>-</sup>) over RS232 or RS485 interfaces {cite}`Beaton2012`. 
 The analyser is capable of measuring concentrations ranging from 0.025 to 1000 µM NO<sub>3</sub> due to the chip containing 3 measurement cells with differing path lengths. 
 Measurement frequency during glider operations is approximately every 7 minutes, this is preceded by a calibration period of approximately 21 minutes during which blank and standard measurements are made at the start of each dive.  
 


### PR DESCRIPTION
Is this superscripted minus sign necessary? We have not used it anywhere else.
Nitrate by itself is an ion, so it should have the minus. But then everywhere or nowhere...